### PR TITLE
enable CORS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,6 +1147,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-register": "^6.26.0",
     "body-parser": "^1.18.2",
     "casual": "^1.5.17",
+    "cors": "^2.8.4",
     "express": "^4.16.2",
     "forever-monitor": "^1.7.1",
     "graphql": "^0.11.7",

--- a/server.js
+++ b/server.js
@@ -1,11 +1,15 @@
 import express from 'express';
 import { graphqlExpress, graphiqlExpress } from 'apollo-server-express';
 import bodyParser from 'body-parser';
+import cors from 'cors';
+
 import schema from './data/schema';
 
 const GRAPHQL_PORT = 3000;
 
 const graphQLServer = express();
+
+graphQLServer.use(cors());
 
 graphQLServer.use('/graphql', bodyParser.json(), graphqlExpress({ schema }));
 graphQLServer.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));


### PR DESCRIPTION
This enables the client to hit the GraphQL server when running on an adjacent port (e.g. in local dev environments) or at a different address. Meets our needs for the spike, but in production we'd probably want to tighten it up a bit.